### PR TITLE
fix to incremental macro

### DIFF
--- a/dbt/brandalley-dbt/macros/streamkap_incremental_on_source_to_current.sql
+++ b/dbt/brandalley-dbt/macros/streamkap_incremental_on_source_to_current.sql
@@ -4,7 +4,8 @@
         source_name,
         id_field,
         source_schema = 'streamkap',
-        order_time_field = '_streamkap_ts_ms',
+        insert_time_field = '_streamkap_ts_ms',
+        order_time_field = '_streamkap_source_ts_ms',
         order_offset_field = '_streamkap_offset',
         deleted_field='__deleted'
     ) -%}
@@ -26,10 +27,10 @@ FROM
 WHERE
     1 = 1
 {% if is_incremental() -%}
-AND {{order_time_field}} >= (
+AND {{insert_time_field}} >= (
     SELECT
         MAX(
-            {{ order_time_field }}
+            {{ insert_time_field }}
         )
     FROM
         {{ this }}


### PR DESCRIPTION
Making this fix to deal with some discrepencies we have been having where some records which show up in the source tables don't show up in the stg tables.

We think this is because the logic has been ordering the records by the insert timestamp field _streamkap_ts_ms which is when streamkap processes the transaction rather than when the transaction happened in the source db.

This change makes the ordering logic (used for choosing the current state of a record), then use _streamkap_source_ts_ms instead.