### PR TITLE
Stock Age work

### DIFF
--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1242,7 +1242,7 @@ models:
               description: 'Qty in Stock'
             summed_stock_qty:
               label: 'Sum of Stock Qty'
-              type: number
+              type: sum
               description: 'Sum of Stock Qty'
       - name: date_arrived
         meta:
@@ -1319,7 +1319,7 @@ models:
               description: 'Qty in Stock'
             summed_stock_qty:
               label: 'Sum of Stock Qty'
-              type: number
+              type: sum
               description: 'Sum of Stock Qty'
       - name: date_arrived
         meta:

--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1280,3 +1280,78 @@ models:
               description: 'The average weighted age when comparing multiple skus'
               type: average
               round: 2
+
+  - name: stock_age_daily
+    description: ""
+    columns:
+      - name: processed_at
+        meta:
+          dimension:
+            hidden: true
+      - name: logged_date
+        meta:
+          dimension:
+            label: 'Logged Date'
+            type: timestamp
+            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
+      - name: sku
+        description: "Sku"
+      - name: ba_site
+      - name: qty_split
+        meta:
+          dimension:
+            hidden: true
+          metrics:
+            stock_qty:
+              label: 'Stock Qty'
+              description: 'Qty in Stock'
+              type: number
+            summed_stock_qty:
+              label: 'Sum of Stock Qty'
+              description: 'Sum of Stock Qty'
+              type: sum
+      - name: date_arrived
+        meta:
+          dimension:
+            label: 'Date Arrived'
+            description: 'Date of Sku arriving'
+            type: timestamp
+            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
+      - name: days_old
+        meta:
+          dimension:
+            label: 'Days Old'
+            description: 'Difference between current date and date of arrival'
+      - name: unit_cost
+        meta:
+          dimension:
+            label: 'Unit Cost'
+            description: 'Cost of Sku'
+          metrics:
+            stock_value_metric:
+              label: 'Stock Value'
+              description: 'Unit cost multiplied by the quantity'
+              type: number
+              sql: "${unit_cost}*${qty_split}"
+              round: 2
+            summed_stock_value_metric:
+              label: 'Sum of Stock Value'
+              description: 'Sum of Stock Value'
+              type: sum
+              sql: "${unit_cost}*${qty_split}"
+              round: 2
+      - name: age_bucket
+        meta:
+          dimension:
+            label: 'Age Bucket'
+      - name: sku_avg_weighted_age
+        meta:
+          dimension:
+            label: 'Average Weighted Age'
+            description: 'The Average Age of the Sku weighted to qty arriving at different times'
+          metrics:
+            avg_weighted_age_metric:
+              label: 'Average Weighted Age Metric'
+              description: 'The average weighted age when comparing multiple skus'
+              type: average
+              round: 2

--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1,6 +1,25 @@
 version: 2
 
 models:
+  - name: stock_age
+    description: ""
+    meta:
+      group_label: 'Products'
+    columns:
+      - name: logged_date
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
+      - name: sku
+      - name: ba_site
+      - name: qty_split
+      - name: date_arrived
+      - name: days_old
+      - name: unit_cost
+      - name: age_bucket
+      - name: avg_weighted_age
+
   - name: catalog_product_negotiation_item
     description: ""
     meta:
@@ -1211,154 +1230,3 @@ models:
         description: "To order qty linked to nego"
       - name: qty_exported
         description: "Quantity exported"
-
-  - name: stock_age
-    description: ""
-    meta:
-      group_label: 'Products'
-    columns:
-      - name: logged_date
-        meta:
-          dimension:
-            label: 'Logged Date'
-            type: timestamp
-            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
-      - name: sku
-        meta:
-          dimension:
-            label: 'Sku'
-      - name: ba_site
-        meta:
-          dimension:
-            label: 'BA Site'
-      - name: qty_split
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            stock_qty:
-              label: 'Stock Qty'
-              type: number
-              description: 'Qty in Stock'
-            summed_stock_qty:
-              label: 'Sum of Stock Qty'
-              type: number
-              description: 'Sum of Stock Qty'
-      - name: date_arrived
-        meta:
-          dimension:
-            label: 'Date Arrived'
-            type: timestamp
-            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
-      - name: days_old
-        meta:
-          dimension:
-            label: 'Days Old'
-      - name: unit_cost
-        meta:
-          dimension:
-            type: number
-            label: 'Unit Cost'
-          metrics:
-            stock_value_metric:
-              label: 'Stock Value'
-              type: number
-              description: 'Unit cost multiplied by the quantity'
-              sql: "${unit_cost}*${qty_split}"
-              round: 2
-            summed_stock_value_metric:
-              label: 'Sum of Stock Value'
-              type: sum
-              description: 'Sum of Stock Value'
-              sql: "${unit_cost}*${qty_split}"
-              round: 2
-      - name: age_bucket
-        meta:
-          dimension:
-            label: 'Age Bucket'
-      - name: sku_avg_weighted_age
-        meta:
-          dimension:
-            label: 'Average Weighted Age'
-            description: 'The Average Age of the Sku weighted to qty arriving at different times'
-          metrics:
-            avg_weighted_age_metric:
-              label: 'Average Weighted Age Metric'
-              type: average
-              description: 'The average weighted age when comparing multiple skus'
-              round: 2
-
-  - name: stock_age_daily
-    description: ""
-    columns:
-      - name: processed_at
-        meta:
-          dimension:
-            hidden: true
-      - name: logged_date
-        meta:
-          dimension:
-            label: 'Logged Date'
-            type: timestamp
-            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
-      - name: sku
-        description: "Sku"
-      - name: ba_site
-      - name: qty_split
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            stock_qty:
-              label: 'Stock Qty'
-              description: 'Qty in Stock'
-              type: number
-            summed_stock_qty:
-              label: 'Sum of Stock Qty'
-              description: 'Sum of Stock Qty'
-              type: sum
-      - name: date_arrived
-        meta:
-          dimension:
-            label: 'Date Arrived'
-            description: 'Date of Sku arriving'
-            type: timestamp
-            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
-      - name: days_old
-        meta:
-          dimension:
-            label: 'Days Old'
-            description: 'Difference between current date and date of arrival'
-      - name: unit_cost
-        meta:
-          dimension:
-            label: 'Unit Cost'
-            description: 'Cost of Sku'
-          metrics:
-            stock_value_metric:
-              label: 'Stock Value'
-              description: 'Unit cost multiplied by the quantity'
-              type: number
-              sql: "${unit_cost}*${qty_split}"
-              round: 2
-            summed_stock_value_metric:
-              label: 'Sum of Stock Value'
-              description: 'Sum of Stock Value'
-              type: sum
-              sql: "${unit_cost}*${qty_split}"
-              round: 2
-      - name: age_bucket
-        meta:
-          dimension:
-            label: 'Age Bucket'
-      - name: sku_avg_weighted_age
-        meta:
-          dimension:
-            label: 'Average Weighted Age'
-            description: 'The Average Age of the Sku weighted to qty arriving at different times'
-          metrics:
-            avg_weighted_age_metric:
-              label: 'Average Weighted Age Metric'
-              description: 'The average weighted age when comparing multiple skus'
-              type: average
-              round: 2

--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1220,10 +1220,17 @@ models:
       - name: logged_date
         meta:
           dimension:
-            hidden: true
+            label: 'Logged Date'
+            type: timestamp
+            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
       - name: sku
-        description: "Sku"
+        meta:
+          dimension:
+            label: 'Sku'
       - name: ba_site
+        meta:
+          dimension:
+            label: 'BA Site'
       - name: qty_split
         meta:
           dimension:
@@ -1231,40 +1238,38 @@ models:
           metrics:
             stock_qty:
               label: 'Stock Qty'
-              description: 'Qty in Stock'
               type: number
+              description: 'Qty in Stock'
             summed_stock_qty:
               label: 'Sum of Stock Qty'
+              type: number
               description: 'Sum of Stock Qty'
-              type: sum
       - name: date_arrived
         meta:
           dimension:
             label: 'Date Arrived'
-            description: 'Date of Sku arriving'
             type: timestamp
             time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
       - name: days_old
         meta:
           dimension:
             label: 'Days Old'
-            description: 'Difference between current date and date of arrival'
       - name: unit_cost
         meta:
           dimension:
+            type: number
             label: 'Unit Cost'
-            description: 'Cost of Sku'
           metrics:
             stock_value_metric:
               label: 'Stock Value'
-              description: 'Unit cost multiplied by the quantity'
               type: number
+              description: 'Unit cost multiplied by the quantity'
               sql: "${unit_cost}*${qty_split}"
               round: 2
             summed_stock_value_metric:
               label: 'Sum of Stock Value'
-              description: 'Sum of Stock Value'
               type: sum
+              description: 'Sum of Stock Value'
               sql: "${unit_cost}*${qty_split}"
               round: 2
       - name: age_bucket
@@ -1279,8 +1284,8 @@ models:
           metrics:
             avg_weighted_age_metric:
               label: 'Average Weighted Age Metric'
-              description: 'The average weighted age when comparing multiple skus'
               type: average
+              description: 'The average weighted age when comparing multiple skus'
               round: 2
 
   - name: stock_age_daily

--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1,7 +1,6 @@
 version: 2
 
 models:
- 
   - name: catalog_product_negotiation_item
     description: ""
     meta:

--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1220,7 +1220,7 @@ models:
       - name: logged_date
         meta:
           dimension:
-            label: 'Logged Date'
+            label: 'Current Date'
             type: timestamp
             time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
       - name: sku
@@ -1235,19 +1235,14 @@ models:
         meta:
           dimension:
             hidden: true
-          metrics:
-            stock_qty:
+            stock_qty_metric:
               label: 'Stock Qty'
-              type: number
-              description: 'Qty in Stock'
-            summed_stock_qty:
-              label: 'Sum of Stock Qty'
               type: sum
-              description: 'Sum of Stock Qty'
+              description: 'Stock Qty'
       - name: date_arrived
         meta:
           dimension:
-            label: 'Date Arrived'
+            label: 'Arrived Date'
             type: timestamp
             time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
       - name: days_old
@@ -1262,12 +1257,6 @@ models:
           metrics:
             stock_value_metric:
               label: 'Stock Value'
-              type: number
-              description: 'Unit cost multiplied by the quantity'
-              sql: "${unit_cost}*${qty_split}"
-              round: 2
-            summed_stock_value_metric:
-              label: 'Sum of Stock Value'
               type: sum
               description: 'Sum of Stock Value'
               sql: "${unit_cost}*${qty_split}"
@@ -1312,19 +1301,14 @@ models:
         meta:
           dimension:
             hidden: true
-          metrics:
-            stock_qty:
+            stock_qty_metric:
               label: 'Stock Qty'
-              type: number
-              description: 'Qty in Stock'
-            summed_stock_qty:
-              label: 'Sum of Stock Qty'
               type: sum
-              description: 'Sum of Stock Qty'
+              description: 'Stock Qty'
       - name: date_arrived
         meta:
           dimension:
-            label: 'Date Arrived'
+            label: 'Arrived Date'
             type: timestamp
             time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
       - name: days_old
@@ -1339,12 +1323,6 @@ models:
           metrics:
             stock_value_metric:
               label: 'Stock Value'
-              type: number
-              description: 'Unit cost multiplied by the quantity'
-              sql: "${unit_cost}*${qty_split}"
-              round: 2
-            summed_stock_value_metric:
-              label: 'Sum of Stock Value'
               type: sum
               description: 'Sum of Stock Value'
               sql: "${unit_cost}*${qty_split}"

--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1211,3 +1211,72 @@ models:
         description: "To order qty linked to nego"
       - name: qty_exported
         description: "Quantity exported"
+
+  - name: stock_age
+    description: ""
+    columns:
+      - name: logged_date
+        meta:
+          dimension:
+            hidden: true
+      - name: sku
+        description: "Sku"
+      - name: ba_site
+      - name: qty_split
+        meta:
+          dimension:
+            hidden: true
+          metrics:
+            stock_qty:
+              label: 'Stock Qty'
+              description: 'Qty in Stock'
+              type: number
+            summed_stock_qty:
+              label: 'Sum of Stock Qty'
+              description: 'Sum of Stock Qty'
+              type: sum
+      - name: date_arrived
+        meta:
+          dimension:
+            label: 'Date Arrived'
+            description: 'Date of Sku arriving'
+            type: timestamp
+            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
+      - name: days_old
+        meta:
+          dimension:
+            label: 'Days Old'
+            description: 'Difference between current date and date of arrival'
+      - name: unit_cost
+        meta:
+          dimension:
+            label: 'Unit Cost'
+            description: 'Cost of Sku'
+          metrics:
+            stock_value_metric:
+              label: 'Stock Value'
+              description: 'Unit cost multiplied by the quantity'
+              type: number
+              sql: "${unit_cost}*${qty_split}"
+              round: 2
+            summed_stock_value_metric:
+              label: 'Sum of Stock Value'
+              description: 'Sum of Stock Value'
+              type: sum
+              sql: "${unit_cost}*${qty_split}"
+              round: 2
+      - name: age_bucket
+        meta:
+          dimension:
+            label: 'Age Bucket'
+      - name: sku_avg_weighted_age
+        meta:
+          dimension:
+            label: 'Average Weighted Age'
+            description: 'The Average Age of the Sku weighted to qty arriving at different times'
+          metrics:
+            avg_weighted_age_metric:
+              label: 'Average Weighted Age Metric'
+              description: 'The average weighted age when comparing multiple skus'
+              type: average
+              round: 2

--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1214,6 +1214,8 @@ models:
 
   - name: stock_age
     description: ""
+    meta:
+      group_label: 'Products'
     columns:
       - name: logged_date
         meta:

--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1,25 +1,7 @@
 version: 2
 
 models:
-  - name: stock_age
-    description: ""
-    meta:
-      group_label: 'Products'
-    columns:
-      - name: logged_date
-        meta:
-          dimension:
-            type: timestamp
-            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
-      - name: sku
-      - name: ba_site
-      - name: qty_split
-      - name: date_arrived
-      - name: days_old
-      - name: unit_cost
-      - name: age_bucket
-      - name: avg_weighted_age
-
+ 
   - name: catalog_product_negotiation_item
     description: ""
     meta:
@@ -1230,3 +1212,156 @@ models:
         description: "To order qty linked to nego"
       - name: qty_exported
         description: "Quantity exported"
+
+  - name: stock_age
+    description: ""
+    meta:
+      group_label: 'Products'
+    columns:
+      - name: logged_date
+        meta:
+          dimension:
+            label: 'Logged Date'
+            type: timestamp
+            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
+      - name: sku
+        meta:
+          dimension:
+            label: 'Sku'
+      - name: ba_site
+        meta:
+          dimension:
+            label: 'BA Site'
+      - name: qty_split
+        meta:
+          dimension:
+            hidden: true
+          metrics:
+            stock_qty:
+              label: 'Stock Qty'
+              type: number
+              description: 'Qty in Stock'
+            summed_stock_qty:
+              label: 'Sum of Stock Qty'
+              type: number
+              description: 'Sum of Stock Qty'
+      - name: date_arrived
+        meta:
+          dimension:
+            label: 'Date Arrived'
+            type: timestamp
+            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
+      - name: days_old
+        meta:
+          dimension:
+            label: 'Days Old'
+      - name: unit_cost
+        meta:
+          dimension:
+            type: number
+            label: 'Unit Cost'
+          metrics:
+            stock_value_metric:
+              label: 'Stock Value'
+              type: number
+              description: 'Unit cost multiplied by the quantity'
+              sql: "${unit_cost}*${qty_split}"
+              round: 2
+            summed_stock_value_metric:
+              label: 'Sum of Stock Value'
+              type: sum
+              description: 'Sum of Stock Value'
+              sql: "${unit_cost}*${qty_split}"
+              round: 2
+      - name: age_bucket
+        meta:
+          dimension:
+            label: 'Age Bucket'
+      - name: sku_avg_weighted_age
+        meta:
+          dimension:
+            label: 'Average Weighted Age'
+            description: 'The Average Age of the Sku weighted to qty arriving at different times'
+          metrics:
+            avg_weighted_age_metric:
+              label: 'Average Weighted Age Metric'
+              type: average
+              description: 'The average weighted age when comparing multiple skus'
+              round: 2
+  
+  - name: stock_age_daily
+    description: ""
+    meta:
+      group_label: 'Products'
+    columns:
+      - name: processed_at
+      - name: logged_date
+        meta:
+          dimension:
+            label: 'Logged Date'
+            type: timestamp
+            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
+      - name: sku
+        meta:
+          dimension:
+            label: 'Sku'
+      - name: ba_site
+        meta:
+          dimension:
+            label: 'BA Site'
+      - name: qty_split
+        meta:
+          dimension:
+            hidden: true
+          metrics:
+            stock_qty:
+              label: 'Stock Qty'
+              type: number
+              description: 'Qty in Stock'
+            summed_stock_qty:
+              label: 'Sum of Stock Qty'
+              type: number
+              description: 'Sum of Stock Qty'
+      - name: date_arrived
+        meta:
+          dimension:
+            label: 'Date Arrived'
+            type: timestamp
+            time_intervals: ['RAW', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
+      - name: days_old
+        meta:
+          dimension:
+            label: 'Days Old'
+      - name: unit_cost
+        meta:
+          dimension:
+            type: number
+            label: 'Unit Cost'
+          metrics:
+            stock_value_metric:
+              label: 'Stock Value'
+              type: number
+              description: 'Unit cost multiplied by the quantity'
+              sql: "${unit_cost}*${qty_split}"
+              round: 2
+            summed_stock_value_metric:
+              label: 'Sum of Stock Value'
+              type: sum
+              description: 'Sum of Stock Value'
+              sql: "${unit_cost}*${qty_split}"
+              round: 2
+      - name: age_bucket
+        meta:
+          dimension:
+            label: 'Age Bucket'
+      - name: sku_avg_weighted_age
+        meta:
+          dimension:
+            label: 'Average Weighted Age'
+            description: 'The Average Age of the Sku weighted to qty arriving at different times'
+          metrics:
+            avg_weighted_age_metric:
+              label: 'Average Weighted Age Metric'
+              type: average
+              description: 'The average weighted age when comparing multiple skus'
+              round: 2

--- a/dbt/brandalley-dbt/models/magento/catalog/stock_age.sql
+++ b/dbt/brandalley-dbt/models/magento/catalog/stock_age.sql
@@ -1,0 +1,76 @@
+{{ config(materialized="table", tags=["job_daily"]) }}
+
+with goods_in_join as (
+    select
+        cast(current_date as date) as logged_date,
+        e.sku,
+        e.ba_site,
+        wsrb.qty_remaining_kettering as stock_qty,
+        cpedcost.value as unit_cost,
+        rgi.qty_arrived,
+        rgi.date_arrived
+    from {{ ref("stg__catalog_product_entity") }} e
+    left join {{ ref("stg__warehouse_stock_running_balance") }} wsrb
+            on wsrb.sku = e.sku
+            and wsrb.ba_site = e.ba_site
+    left join {{ ref("stg__catalog_product_entity_decimal") }} cpedcost
+            on cpedcost.attribute_id = 79
+            and cpedcost.entity_id = e.entity_id
+            and e.ba_site = cpedcost.ba_site
+    left join {{ ref("stg__reactor_goods_in") }} rgi
+            on e.sku = rgi.sku
+            and cast(current_date as date) >= rgi.date_arrived  -- might need to think about this when france warehouse closes?
+    where wsrb.qty_remaining_kettering > 0
+),
+running_qty as (
+    select
+        a.logged_date,
+        a.sku,
+        a.ba_site,
+        a.stock_qty,
+        a.unit_cost,
+        a.qty_arrived,
+        sum(a.qty_arrived) over (partition by a.sku, a.ba_site order by a.date_arrived desc) as running_quantity,
+        ifnull(a.date_arrived, b.delivery_date) as date_arrived,
+        ifnull(date_diff(a.logged_date, a.date_arrived, day),date_diff(a.logged_date, b.delivery_date, day)) as days_old
+    from goods_in_join a
+    left join (select sku, delivery_date, ba_site
+               from {{ ref("stg__stock_prism_grn_item") }}
+               qualify row_number() over (partition by sku, ba_site order by delivery_date desc)= 1) b
+            on a.sku = b.sku
+            and a.ba_site = b.ba_site
+),
+skus_seperated as (
+    select
+        logged_date,
+        sku,
+        ba_site,
+        case when running_quantity <= stock_qty then qty_arrived
+             when running_quantity is null then stock_qty
+             else stock_qty - (running_quantity - qty_arrived) end as qty_split,
+        date_arrived,
+        days_old as days_old,
+        unit_cost
+    from running_qty a
+    where case when running_quantity <= stock_qty then qty_arrived
+               when running_quantity is null then stock_qty
+               else stock_qty - (running_quantity - qty_arrived) end > 0
+--and days_old is null
+)
+select
+    a.logged_date,
+    a.sku,
+    a.ba_site,
+    a.qty_split,
+    a.date_arrived,
+    a.days_old,
+    a.unit_cost,
+    case when a.days_old > 365 then 'Over 12 Months'
+         when a.days_old > 274 and a.days_old <= 365 then '10-12 Months'
+         when a.days_old > 180 and a.days_old <= 274 then '7-9 Months'
+         when a.days_old > 90 and a.days_old <= 180 then '4-6 Months'
+         when a.days_old is null then 'No Deliveries'
+         else '0-3 Months' end as age_bucket,
+    (sum((qty_split * days_old)) over (partition by sku, ba_site)) / (sum(qty_split) over (partition by sku, ba_site)) as sku_avg_weighted_age
+from skus_seperated a
+--where sku in ('18278977','18448568') happy with weighted age

--- a/dbt/brandalley-dbt/models/magento/catalog/stock_age.sql
+++ b/dbt/brandalley-dbt/models/magento/catalog/stock_age.sql
@@ -3,7 +3,7 @@
 with goods_in_join as (
     select
         cast(current_date as date) as logged_date,
-        e.sku,
+        e.sku as sku,
         e.ba_site,
         wsrb.qty_remaining_kettering as stock_qty,
         cpedcost.value as unit_cost,
@@ -55,7 +55,6 @@ skus_seperated as (
     where case when running_quantity <= stock_qty then qty_arrived
                when running_quantity is null then stock_qty
                else stock_qty - (running_quantity - qty_arrived) end > 0
---and days_old is null
 )
 select
     a.logged_date,
@@ -73,4 +72,3 @@ select
          else '0-3 Months' end as age_bucket,
     round((sum((qty_split * days_old)) over (partition by sku, ba_site)) / (sum(qty_split) over (partition by sku, ba_site)),2) as sku_avg_weighted_age
 from skus_seperated a
---where sku in ('18278977','18448568') happy with weighted age

--- a/dbt/brandalley-dbt/models/magento/catalog/stock_age.sql
+++ b/dbt/brandalley-dbt/models/magento/catalog/stock_age.sql
@@ -3,23 +3,19 @@
 with goods_in_join as (
     select
         cast(current_date as date) as logged_date,
-        e.sku as sku,
-        e.ba_site,
+        p.variant_sku as sku,
+        p.ba_site,
         wsrb.qty_remaining_kettering as stock_qty,
-        cpedcost.value as unit_cost,
+        p.cost as unit_cost,
         rgi.qty_arrived,
         rgi.date_arrived
-    from {{ ref("stg__catalog_product_entity") }} e
+    from {{ ref("products") }} p
     left join {{ ref("stg__warehouse_stock_running_balance") }} wsrb
-            on wsrb.sku = e.sku
-            and wsrb.ba_site = e.ba_site
-    left join {{ ref("stg__catalog_product_entity_decimal") }} cpedcost
-            on cpedcost.attribute_id = 79
-            and cpedcost.entity_id = e.entity_id
-            and e.ba_site = cpedcost.ba_site
+            on wsrb.sku = p.variant_sku
+            and wsrb.ba_site = p.ba_site
     left join {{ ref("stg__reactor_goods_in") }} rgi
-            on e.sku = rgi.sku
-            and cast(current_date as date) >= rgi.date_arrived  -- might need to think about this when france warehouse closes?
+            on p.variant_sku = rgi.sku
+            and cast(current_date as date) >= rgi.date_arrived  -- might need to think about this when france warehouse closes? join to reactor on sku?
     where wsrb.qty_remaining_kettering > 0
 ),
 running_qty as (

--- a/dbt/brandalley-dbt/models/magento/catalog/stock_age.sql
+++ b/dbt/brandalley-dbt/models/magento/catalog/stock_age.sql
@@ -71,6 +71,6 @@ select
          when a.days_old > 90 and a.days_old <= 180 then '4-6 Months'
          when a.days_old is null then 'No Deliveries'
          else '0-3 Months' end as age_bucket,
-    (sum((qty_split * days_old)) over (partition by sku, ba_site)) / (sum(qty_split) over (partition by sku, ba_site)) as sku_avg_weighted_age
+    round((sum((qty_split * days_old)) over (partition by sku, ba_site)) / (sum(qty_split) over (partition by sku, ba_site)),2) as sku_avg_weighted_age
 from skus_seperated a
 --where sku in ('18278977','18448568') happy with weighted age

--- a/dbt/brandalley-dbt/models/magento/catalog/stock_age_daily.sql
+++ b/dbt/brandalley-dbt/models/magento/catalog/stock_age_daily.sql
@@ -1,0 +1,14 @@
+
+{{ config(
+    full_refresh=false,
+    on_schema_change='sync_all_columns',
+    materialized='incremental'
+) }}
+
+select 
+    current_timestamp as processed_at,
+    * 
+from {{ ref('stock_age') }}
+{% if is_incremental() %}
+where current_date > (select max(logged_date) from {{this}})
+{% endif %}

--- a/dbt/brandalley-dbt/models/magento/catalog/stock_age_daily.sql
+++ b/dbt/brandalley-dbt/models/magento/catalog/stock_age_daily.sql
@@ -2,7 +2,8 @@
 {{ config(
     full_refresh=false,
     on_schema_change='sync_all_columns',
-    materialized='incremental'
+    materialized='incremental',
+    tags=["job_daily"]
 ) }}
 
 select 

--- a/dbt/brandalley-dbt/models/magento/catalog/stock_file.sql
+++ b/dbt/brandalley-dbt/models/magento/catalog/stock_file.sql
@@ -1,3 +1,5 @@
+{{ config(materialized="table", tags=["job_daily"]) }}
+
 with stock_file_raw as (
     select 
         e.ba_site || '-' || e.entity_id                 as ba_site_child_entity_id,

--- a/dbt/brandalley-dbt/models/magento/catalog/stock_file_daily.sql
+++ b/dbt/brandalley-dbt/models/magento/catalog/stock_file_daily.sql
@@ -2,7 +2,8 @@
 {{ config(
     full_refresh=false,
     on_schema_change='sync_all_columns',
-    materialized='incremental'
+    materialized='incremental',
+    tags=["job_daily"]
 ) }}
 
 select 

--- a/dbt/brandalley-dbt/models/reactor/_docs.yml
+++ b/dbt/brandalley-dbt/models/reactor/_docs.yml
@@ -41,3 +41,12 @@ models:
       - name: unsellable
       - name: unsellable_good
       - name: unsellable_bad
+
+  - name: stg__reactor_goods_in
+    description: ""
+    columns:
+      - name: po_id
+      - name: sku
+      - name: date_arrived
+      - name: qty_arrived
+      - name: src

--- a/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
+++ b/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
@@ -1,4 +1,4 @@
-{{ config(materialized="table", tags=["reactor_stock_daily"]) }}
+{{ config(materialized="table", tags=["job_daily"]) }}
 
 with
     kettering_goods_in as (
@@ -18,7 +18,7 @@ with
         select
             poi.po_id as purchase_id,
             poi.sku as magento_sku,
-            cast(spgi.delivery_date as date) as date_arrived,
+            ifnull(cast(spgi.delivery_date as date), cast(po.delivery_date as date)) as date_arrived,
             sum(to_order) as qty_arrived
         from {{ ref("stg__catalog_product_po_item") }} poi
         inner join

--- a/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
+++ b/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
@@ -1,0 +1,67 @@
+{{ config(materialized="table", tags=["reactor_stock_daily"]) }}
+
+with
+    kettering_goods_in as (
+        select
+            psl.purchaseid as purchase_id,
+            sl.legacy_id as magento_sku,
+            cast(
+                datetime_add('1970-01-01', interval psl.timestamp second) as date
+            ) as date_arrived,
+            sum(psl.newly_received_quantity) as qty_arrived,
+        from {{ ref("stg__purchasestocklog") }} psl
+        left join {{ ref("stg__stocklist") }} sl on psl.stockid = sl.id
+        where length(cast(psl.purchaseid as string)) > 8
+        group by 1, 2, 3
+    ),
+    pre_kettering as (
+        select
+            poi.po_id as purchase_id,
+            poi.sku as magento_sku,
+            cast(spgi.delivery_date as date) as date_arrived,
+            sum(to_order) as qty_arrived
+        from {{ ref("stg__catalog_product_po_item") }} poi
+        inner join
+            {{ ref("stg__catalog_product_po") }} po
+            on poi.po_id = po.po_id
+            and poi.ba_site = po.ba_site
+        left join
+            {{ ref("stg__stock_prism_grn") }} spg
+            on cast(spg.purchase_order_reference as integer) = po.po_id
+            and po.ba_site = spg.ba_site
+        left join
+            {{ ref("stg__stock_prism_grn_item") }} spgi
+            on spgi.grn_id = spg.grn_id
+            and spgi.sku = poi.sku
+            and poi.ba_site = spgi.ba_site
+        left join
+            kettering_goods_in kgi
+            on cast(poi.po_id as string) = substring(
+                cast(kgi.purchase_id as string),
+                1,
+                char_length(cast(kgi.purchase_id as string)) - 2
+            )
+            and poi.sku = kgi.magento_sku
+        where kgi.purchase_id is null
+        group by 1, 2, 3
+    )
+select
+    cast(
+        substring(
+            cast(purchase_id as string), 1, char_length(cast(purchase_id as string)) - 2
+        ) as int
+    ) as po_id,
+    magento_sku as sku,
+    date_arrived,
+    qty_arrived,
+    'purchasestock' as src
+from kettering_goods_in
+union all
+select
+    purchase_id as po_id,
+    magento_sku as sku,
+    date_arrived,
+    qty_arrived,
+    'magento' as src
+from pre_kettering
+


### PR DESCRIPTION
- Goods in model combines date from purchasestocklog in reactor and historic numbers from grn_delivery_date in magento.
- Stock age model
- Stock age daily (built this for the last 3 days)
- docs.yml for both the above
- Configurations changed. Stockfile runs once on daily run as stock is being allocated constantly throughout the day meaning numbers are changing. Tidied up configuration on stock_file_daily to include the tag.