### PR TITLE
updating stock age and goods in

### DIFF
--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -1216,6 +1216,10 @@ models:
     description: ""
     meta:
       group_label: 'Products'
+      joins:
+        - join: stock_file
+          sql_on: ${stock_age.sku} = ${stock_file.child_sku} and ${stock_age.ba_site} = ${stock_file.ba_site}
+          
     columns:
       - name: logged_date
         meta:
@@ -1282,6 +1286,10 @@ models:
     description: ""
     meta:
       group_label: 'Products'
+      joins:
+        - join: stock_file_daily
+          sql_on: ${stock_age_daily.logged_date} = ${stock_file_daily.stock_file_date} and ${stock_age_daily.sku} = ${stock_file_daily.child_sku} and ${stock_age_daily.ba_site} = ${stock_file_daily.ba_site}
+
     columns:
       - name: processed_at
       - name: logged_date

--- a/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
+++ b/dbt/brandalley-dbt/models/magento/catalog/_docs.yml
@@ -775,6 +775,190 @@ models:
           dimension:
             label: 'Tax Rate'
 
+  - name: stock_file_daily
+    description: ""
+    meta:
+      group_label: 'Products'
+    columns:
+      - name: stock_file_date
+        meta:
+          dimension:
+            label: 'Stock File Date'
+            description: 'Stock file at specified date'
+      - name: processed_at
+        meta:
+          dimension:
+            hidden: true
+      - name: ba_site_child_entity_id
+        description: "Primary Key"
+        tests:
+          - unique
+          - not_null
+        meta:
+          dimension:
+            format: id
+          metrics:
+            count_refunds_metric:
+              label: 'Total number of entity id'
+              type: count_distinct
+              description: "Number of entity id"
+              hidden: false
+              round: 0 
+      - name: ba_site
+      - name: child_entity_id
+        description: "Primary Key at site level"
+      - name: child_sku
+        description: "child sku, nullable"
+      - name: min_qty
+        description: "Quantity min, nullable"
+      - name: qty
+        description: "Quantity, nullable"
+        tests:
+          - stock_file_qty 
+      - name: stock_kettering
+        meta:
+          metrics:
+            total_stock_kettering:
+              type: sum
+            total_ttl_flash_kettering:
+              type: sum
+              sql: '${special_price}*${stock_kettering}'
+            total_ttl_cost_kettering:
+              type: sum
+              sql: '${cost}*${stock_kettering}'
+      - name: stock_prism
+        meta:
+          metrics:
+            total_stock_prism:
+              type: sum
+            total_ttl_flash_prism:
+              type: sum
+              sql: '${special_price}*${stock_prism}'
+            total_ttl_cost_prism:
+              type: sum
+              sql: '${cost}*${stock_prism}'
+      - name: stock_sed
+        meta:
+          metrics:
+            total_stock_sed:
+              type: sum
+            total_ttl_flash_sed:
+              type: sum
+              sql: '${special_price}*${stock_sed}'
+            total_ttl_cost_sed:
+              type: sum
+              sql: '${cost}*${stock_sed}'
+      - name: stock_kettering_allocated
+        meta:
+          metrics:
+            total_stock_kettering_allocated:
+              type: sum
+              label: 'Allocated Stock Qty'
+      - name: stock_kettering_unsellable_good
+        meta:
+          metrics:
+            total_stock_kettering_unsellable_good:
+              type: sum
+              label: 'Unsellable Location Stock Qty'
+      - name: stock_kettering_unsellable_bad
+        meta:
+          metrics:
+            total_stock_kettering_unsellable_bad:
+              type: sum
+              label: 'Unsellable Damaged Stock Qty'
+      - name: image_value
+        description: "Image value, nullable"
+      - name: name
+        description: "name, nullable"
+      - name: value
+        description: "Base adjustement negative, nullable"
+      - name: suplier_id
+        description: "suplier id, nullable"
+        meta:
+          dimension:
+            format: id
+      - name: brand
+        description: "Brand, nullable"
+      - name: country_of_manufacture
+        description: "Country of manufacture, nullable"
+      - name: cost
+        description: "cost, nullable"
+      - name: parent_gender
+        description: "Parent gender, nullable"
+      - name: simple_gender
+        description: "Gender of the simple item, nullable"
+      - name: simple_product_type
+        description: "Simple product type, nullable"
+      - name: parent_product_type
+        description: "Parent product type, nullable"
+      - name: size
+        description: "Size, nullable"
+      - name: colour
+        description: "Colour, nullable"
+      - name: price
+        description: "Price, nullable"
+      - name: special_price
+        description: "Special price, nullable"
+      - name: outlet_price
+        description: "Outlet price, nullable"
+      - name: outlet_category
+        description: "Outlet category, nullable"
+      - name: canUseForWHSale
+        description: "Can use for warehouse sale flag, nullable"
+        meta:
+          dimension:
+            label: 'Can Use For WH Sale'
+      - name: barcode
+        description: "Barcode, nullable"
+      - name: nego
+        description: "Nego number, nullable"
+      - name: buyer_id
+        description: "Buyer id, nullable"
+        meta:
+          dimension:
+            format: id
+      - name: buyer
+        description: "Buyer, nullable"
+      - name: level_1
+        description: "Level 1 of categories"
+      - name: level_2
+        description: "Level 2 of categories"
+      - name: level_3
+        description: "Level 3 of categories"
+      - name: parent_category
+        description: "Parent category"
+      - name: flashsale_category
+        description: "Flash sale category"
+      - name: supplier_name
+        description: "Supplier name"
+      - name: child_parent_sku
+        description: "Child parent SKU"
+      - name: last_stock_delivery_date
+      - name: child_parent_sku_age_days
+        meta:
+          dimension:
+            sql: 'date_diff(current_date, ${last_stock_delivery_date}, day)'
+      - name: child_parent_sku_age_bucket
+        meta:
+          dimension:
+            sql: > 
+              case 
+                when date_diff(current_date, ${last_stock_delivery_date}, day) > 365 then 'Over 1 Year'
+                when date_diff(current_date, ${last_stock_delivery_date}, day) > 274 then '9 - 12 Months'
+                when date_diff(current_date, ${last_stock_delivery_date}, day) > 180 then '6 - 9 Months'
+                when date_diff(current_date, ${last_stock_delivery_date}, day) > 89 then '3 - 6 Months'
+                when date_diff(current_date, ${last_stock_delivery_date}, day) > 30 then '1 - 3 Months'
+                when ${last_stock_delivery_date} is null then 'No Deliveries'
+                else 'Up to 1 Month'
+              end
+      - name: category
+        description: "Category as defined by buyers"
+      - name: tax
+        description: "Tax percentage"
+        meta:
+          dimension:
+            label: 'Tax Rate'
+            
   - name: catalog_category_flat_store_1_enriched
     description: ""
     columns:

--- a/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
+++ b/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
@@ -14,11 +14,34 @@ with
         where length(cast(psl.purchaseid as string)) > 8
         group by 1, 2, 3
     ),
+    negative_goods_in as (
+        select
+            *,
+            lag(qty_arrived, 1) over (
+                partition by purchase_id, magento_sku order by date_arrived desc
+            ) as previous_qty_arrived
+        from kettering_goods_in
+    ),
+    kettering_goods_in_correction as (
+        select
+            purchase_id,
+            magento_sku,
+            date_arrived,
+            case
+                when previous_qty_arrived < 0
+                then qty_arrived + previous_qty_arrived
+                else qty_arrived
+            end as qty_arrived
+        from negative_goods_in a
+        where a.qty_arrived > 0 --this has been added as occassionally kettering check in more than they actually got and thus create a correction with a negative number. So here we are taking that negative number off previous row.
+    ),
     pre_kettering as (
         select
             poi.po_id as purchase_id,
             poi.sku as magento_sku,
-            ifnull(cast(spgi.delivery_date as date), cast(po.delivery_date as date)) as date_arrived,
+            ifnull(
+                cast(spgi.delivery_date as date), cast(po.delivery_date as date)
+            ) as date_arrived,
             sum(to_order) as qty_arrived
         from {{ ref("stg__catalog_product_po_item") }} poi
         inner join
@@ -35,14 +58,14 @@ with
             and spgi.sku = poi.sku
             and poi.ba_site = spgi.ba_site
         left join
-            kettering_goods_in kgi
+            kettering_goods_in_correction kgic
             on cast(poi.po_id as string) = substring(
-                cast(kgi.purchase_id as string),
+                cast(kgic.purchase_id as string),
                 1,
-                char_length(cast(kgi.purchase_id as string)) - 2
+                char_length(cast(kgic.purchase_id as string)) - 2
             )
-            and poi.sku = kgi.magento_sku
-        where kgi.purchase_id is null
+            and poi.sku = kgic.magento_sku
+        where kgic.purchase_id is null
         group by 1, 2, 3
     )
 select
@@ -55,7 +78,7 @@ select
     date_arrived,
     qty_arrived,
     'purchasestock' as src
-from kettering_goods_in
+from kettering_goods_in_correction
 union all
 select
     purchase_id as po_id,
@@ -64,4 +87,3 @@ select
     qty_arrived,
     'magento' as src
 from pre_kettering
-


### PR DESCRIPTION
1. Joined to the stock_file and stock_file_daily in docs.yml, a sku by site is unique in the stockfile so should be s ound join. This is so I can report on the data by brand and other granularities

Fixed Issues:
1. Missing Deliveries fix. Occasionally, there can be times when no deliveries are present in purchase order data, flagged it with shardendu and he said he doesn't have time to look at it at the moment basically. Already had a bucket for no deliveries to account for this. But didn't account for when we had deliveries but not enough to cover the stock qty. In these cases I've added a sub query to identify these skus and appended the remaining stock in a union under the 'no deliveries' bucket.
2. Goods in Fix. So when kettering check in more stock than they actually received (doesn't happen often), they manually insert a row which is a negative qty received. Having a negative qty_arrived causes issues in the case when in stock age model, so to fix this I've used lag function in the goods in model which takes that negative qty away from the previous row as that is what the correction is meant to do. Goods in should read true now and thus the negative quantities gone.

Any questions if any of that doesn't make sesnse, let me know!