### PR TITLE
Changes to goods in for warehouse KPIs

### DIFF
--- a/dbt/brandalley-dbt/models/reactor/_docs.yml
+++ b/dbt/brandalley-dbt/models/reactor/_docs.yml
@@ -109,6 +109,65 @@ models:
           dimension:
             label: 'Stock Type'
 
+  - name: stg__reactor_goods_in_checked_date
+    description: ""
+    columns:
+      - name: po_id
+        meta:
+          dimension:
+            label: 'PO ID'
+          metrics:
+            goods_in_pos:
+              label: 'Goods In POs'
+              type: count_distinct
+              description: 'Number of POs Checked in'
+              round: 0
+      - name: sku
+        meta:
+          dimension:
+            label: 'Magento SKU'
+      - name: date_arrived
+        meta:
+          dimension:
+            type: date
+            time_intervals: ['RAW', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', 'DAY_OF_WEEK_NAME', 'MONTH_NAME', 'QUARTER_NAME']
+            label: 'Arrived Date'
+      - name: qty_arrived
+        meta:
+          dimension:
+            label: 'Qty Arrived'
+          metrics:
+            goods_in_qty_sum:
+              label: 'Goods In Qty'
+              type: sum
+              description: 'Number of Units Checked in'
+              round: 0
+            x_dock_goods_in_qty_sum:
+              label: 'X Dock Goods In Qty'
+              type: sum
+              description: 'Number of X Dock units checked in'
+              sql: "if(${stock_type} = 'X Dock', ${qty_arrived}, 0)"
+              round: 0
+            pct_of_goods_in_x_dock:
+              label: '% X Dock Goods In'
+              type: number
+              format: 'percent'
+              description: 'Percent of units checked in which are x dock'
+              sql: "safe_divide(${x_dock_goods_in_qty_sum},${goods_in_qty_sum})"
+              round: 2
+      - name: supplier
+        meta:
+          dimension:
+            label: 'Supplier'
+      - name: company
+        meta:
+          dimension:
+            label: 'Company'
+      - name: stock_type
+        meta:
+          dimension:
+            label: 'Stock Type'
+
   - name: stock_exited
     description: ""
     columns:

--- a/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
+++ b/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
@@ -83,7 +83,7 @@ with
                 char_length(cast(kgic.purchase_id as string)) - 2
             )
             and poi.sku = kgic.magento_sku
-        where kgic.purchase_id is null and ifnull(cast(spgi.delivery_date as date), cast(po.delivery_date as date)) < current_date and spg.purchase_order_reference is not null
+        where kgic.purchase_id is null and spgi.grn_id is not null
         group by 1, 2, 3, 5
     )
 select

--- a/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
+++ b/dbt/brandalley-dbt/models/reactor/stg__reactor_goods_in.sql
@@ -83,7 +83,7 @@ with
                 char_length(cast(kgic.purchase_id as string)) - 2
             )
             and poi.sku = kgic.magento_sku
-        where kgic.purchase_id is null
+        where kgic.purchase_id is null and ifnull(cast(spgi.delivery_date as date), cast(po.delivery_date as date)) < current_date
         group by 1, 2, 3, 5
     )
 select

--- a/dbt/brandalley-dbt/models/reactor/warehouse_kpis_daily.sql
+++ b/dbt/brandalley-dbt/models/reactor/warehouse_kpis_daily.sql
@@ -22,7 +22,7 @@ with
             sum(gi.qty_arrived) as goods_in_qty,
             sum(if(gi.stock_type = 'X Dock', qty_arrived, 0)) as x_dock_goods_in_qty,
             round(sum(if(gi.stock_type = 'X Dock', qty_arrived, 0)) / sum(gi.qty_arrived),2) as pct_goods_in_x_dock
-        from {{ ref("stg__reactor_goods_in") }} gi
+        from {{ ref("stg__reactor_goods_in_checked_date") }} gi
         group by 1
     ),
     returns_kpis as (


### PR DESCRIPTION
The goods in I built is for stock ageing purposes which means the date arrived in the existing model is referencing the original date arrived (if it arrived pre kettering). But what warehouse want to see is the amount of goods checked in at the time of check in to kettering (not interested in when it originally arrived) so new model for that which is similar.

Also added in the where clause of existing model as occassionally it was including skus that haven't arrived yet. (this isn't a big deal as its on the right side of the join in stock age so if it wasn't in stock yet it wouldn't get an age. But corrected anyway.

Let me know if any questions