### PR TITLE
gsheet forecast and reactor stock locs

### DIFF
--- a/dbt/brandalley-dbt/models/core/forecasts/_sources.yml
+++ b/dbt/brandalley-dbt/models/core/forecasts/_sources.yml
@@ -1,0 +1,7 @@
+version: 2
+
+sources:
+  - name: core
+    database: datawarehouse-358408
+    tables:
+      - name: stock_sales_forecast_gsheet

--- a/dbt/brandalley-dbt/models/core/forecasts/sales_forecast.sql
+++ b/dbt/brandalley-dbt/models/core/forecasts/sales_forecast.sql
@@ -9,4 +9,3 @@ select
     department,
     sales_forecast
 from {{ source('core', 'stock_sales_forecast_gsheet') }}
-where target_date is not null

--- a/dbt/brandalley-dbt/models/core/forecasts/sales_forecast.sql
+++ b/dbt/brandalley-dbt/models/core/forecasts/sales_forecast.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='table'
+) }}
+
+
+select 
+    month_start_date,
+    month_name,
+    department,
+    sales_forecast
+from {{ source('core', 'stock_sales_forecast_gsheet') }}
+where target_date is not null

--- a/dbt/brandalley-dbt/models/reactor/_docs.yml
+++ b/dbt/brandalley-dbt/models/reactor/_docs.yml
@@ -711,6 +711,8 @@ models:
       joins:
         - join: box_names
           sql_on: ${box_stock_locations.box_id} = ${box_names.box_id}
+        - join: stocklist_product_info
+          sql_on: ${box_stock_locations.reactor_sku_id} = ${stocklist_product_info.reactor_sku}
     columns:
       - name: logged_date
         meta:
@@ -758,6 +760,24 @@ models:
               label: 'Total Qty Available'
               type: sum
               description: 'Sum of total available qty'
+      - name: unsellable_good
+        meta:
+          dimension:
+            label: 'Qty Unsellable Location'
+          metrics:
+            qty_unsellable_good_sum:
+              label: 'Total Unsellable Location'
+              type: sum
+              description: 'Sum of total qty in an unsellable location'
+      - name: unsellable_bad
+        meta:
+          dimension:
+            label: 'Qty Unsellable Damaged'
+          metrics:
+            qty_unsellable_bad_sum:
+              label: 'Total Qty Unsellable Damaged'
+              type: sum
+              description: 'Sum of total available qty in an unsellable damaged location'
 
   - name: warehouse_kpis_daily
     description: ""

--- a/dbt/brandalley-dbt/models/reactor/box_stock_locations.sql
+++ b/dbt/brandalley-dbt/models/reactor/box_stock_locations.sql
@@ -24,6 +24,23 @@ from {{ ref("stg__orderboxindex") }} as obi
 inner join {{ ref("stg__orders") }} as o on obi.orderid = o.orderid
 left join {{ ref("stg__stocklist") }} sl on o.stockid = sl.id
 where obi.__deleted = false
+
+
+union all
+
+select cast(current_date as date) as logged_date,
+       ubsi.stockid as reactor_sku_id,
+       sl.legacy_id as sku,
+       ubsi.quantity as quantity,
+       ubsi.boxid as box_id, 
+       'unsellable' as stock_type       
+from {{ ref("stg__unsellableboxstockindex") }} ubsi
+left join {{ ref("stg__box") }} as b on ubsi.boxid = b.id
+left join {{ ref("stg__boxracking") }} as br on br.id = b.boxrackingid
+left join {{ ref("stg__adboxaisle") }} as aba on aba.aisleid = br.aisleid
+left join {{ ref("stg__adboxzone") }} as abz on abz.zoneid = aba.zoneid
+left join {{ ref("stg__stocklist") }} sl on ubsi.stockid = sl.id
+where abz.name <> 'z Bulk Zone GI Bay'
 )
 select
 	rsp.logged_date,
@@ -31,11 +48,17 @@ select
 	max(rsp.reactor_sku_id) as reactor_sku_id,
     rsp.box_id,
 	sum(rsp.quantity) as on_hand,
-	sum(case when rsp.stock_type = 'allocated'
+	sum(case when rsp.stock_type in ('allocated')
 		then rsp.quantity
 	    else 0 end) as allocated,
 	sum(case when rsp.stock_type = 'available'
 		then rsp.quantity
 	    else 0 end) as available,
+    sum(case when rsp.stock_type = 'unsellable' and rsp.box_id not in (-32, -33, -34, -35, -41, -42)
+		then rsp.quantity
+	    else 0 end) as unsellable_good,
+    sum(case when rsp.stock_type = 'unsellable' and rsp.box_id in (-32, -33, -34, -35, -41, -42)
+		then rsp.quantity
+	    else 0 end) as unsellable_bad,
 from raw_stock_profile as rsp
 group by 1,2,4

--- a/dbt/brandalley-dbt/models/reactor/box_stock_locations.sql
+++ b/dbt/brandalley-dbt/models/reactor/box_stock_locations.sql
@@ -48,7 +48,7 @@ select
 	max(rsp.reactor_sku_id) as reactor_sku_id,
     rsp.box_id,
 	sum(rsp.quantity) as on_hand,
-	sum(case when rsp.stock_type in ('allocated')
+	sum(case when rsp.stock_type = 'allocated'
 		then rsp.quantity
 	    else 0 end) as allocated,
 	sum(case when rsp.stock_type = 'available'

--- a/dbt/brandalley-dbt/models/reactor/stg__reactor_stock_profile.sql
+++ b/dbt/brandalley-dbt/models/reactor/stg__reactor_stock_profile.sql
@@ -57,41 +57,6 @@ where obi.__deleted = false
 
 union all
 
-select
-    cast(current_date as date) as logged_date,
-    o.stockid as reactor_sku_id,
-    sl.legacy_id as sku,
-    sum(o.quantity) as quantity,
-    null as box_id,
-    null as rack_id,
-    null as rack_row,
-    null as rack,
-    null as rack_number,
-    null as aisle_id,
-    null as aisle_number,
-    null as zone_id,
-    null as zone_name,
-    null as zone_abbr,
-    null as zone_colour,
-    0 as is_zone_pickable,
-    'pending dispatch' as stock_type
-from {{ ref("stg__orders") }} as o
-inner join
-    {{ ref("stg__customers") }} as c
-    on c.customerid = o.customerid
-    and c.deleted is null
-left join
-    (select * from {{ ref("stg__orderboxindex") }} where __deleted = false) obi
-    on obi.orderid = o.orderid
-left join {{ ref("stg__stocklist") }} sl on o.stockid = sl.id
-where
-    o.completed_timestamp is not null
-    and o.leftwarehouse_timestamp < '2000-01-01'
-    and obi.id is null
-group by o.stockid, sl.legacy_id
-
-union all
-
 select cast(current_date as date) as logged_date,
        ubsi.stockid as reactor_sku_id,
        sl.legacy_id as sku,

--- a/dbt/brandalley-dbt/models/reactor/stg__reactor_stock_profile.sql
+++ b/dbt/brandalley-dbt/models/reactor/stg__reactor_stock_profile.sql
@@ -87,7 +87,7 @@ select
 	rsp.sku,
 	max(rsp.reactor_sku_id) as reactor_sku_id,
 	sum(rsp.quantity) as on_hand,
-	sum(case when rsp.stock_type in ('allocated', 'pending dispatch')
+	sum(case when rsp.stock_type = 'allocated'
 		then rsp.quantity
 	    else 0 end) as allocated,
 	sum(case when rsp.stock_type = 'available'


### PR DESCRIPTION
- removing pending dispatch from stock as was double counting (minimal)
- adding unsellable to stock locations
- adding join in stock location docs
- sales forecast